### PR TITLE
Replace gonum with simple topological sort

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -1,0 +1,4 @@
+{
+  "Cyclo": 15,
+  "Deadline": "30s"
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
 script:
   - go install -v ./...
   - go test -v ./...
-  - $HOME/gopath/bin/gometalinter ./... --deadline=30s --cyclo-over=12
+  - $HOME/gopath/bin/gometalinter
 
 after_script:
   - go test -covermode=count -coverprofile=profile.cov

--- a/resolve.go
+++ b/resolve.go
@@ -6,9 +6,6 @@ import (
 	"strings"
 
 	"github.com/codegangsta/inject"
-	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/simple"
-	"gonum.org/v1/gonum/graph/topo"
 )
 
 // It is more of a pain than it should be to get an interface type as just
@@ -37,24 +34,19 @@ func EnsureValidFactory(item interface{}) error {
 }
 
 type funcNode struct {
-	graph.Node
-
 	provides []reflect.Type
 	requires []reflect.Type
 
 	raw interface{}
 }
 
-func newFuncNode(node graph.Node, item interface{}) (*funcNode, error) {
+func newFuncNode(item interface{}) (*funcNode, error) {
 	err := EnsureValidFactory(item)
 	if err != nil {
 		return nil, err
 	}
 
-	n := &funcNode{
-		Node: node,
-		raw:  item,
-	}
+	n := &funcNode{raw: item}
 
 	// We've already ensured that this is a factory in
 	// EnsureValidFactory, so we don't need to do it again here.
@@ -76,23 +68,22 @@ func newFuncNode(node graph.Node, item interface{}) (*funcNode, error) {
 // Resolver is a set of values which, when called in the proper order, contain
 // all the requirements as return values of other functions.
 type Resolver struct {
-	graph      *simple.DirectedGraph
-	providedBy map[reflect.Type]graph.Node
+	nodes      []*funcNode
+	providedBy map[reflect.Type]*funcNode
 }
 
 // NewResolver returns an empty resolve set which can be used for resolving
 // function calls.
 func NewResolver() *Resolver {
 	return &Resolver{
-		graph:      simple.NewDirectedGraph(),
-		providedBy: make(map[reflect.Type]graph.Node),
+		providedBy: make(map[reflect.Type]*funcNode),
 	}
 }
 
 // AddNode adds a function to an internal graph of dependencies. The resolution
 // will be done when Resolve is called.
 func (r *Resolver) AddNode(item interface{}) error {
-	n, err := newFuncNode(r.graph.NewNode(), item)
+	n, err := newFuncNode(item)
 	if err != nil {
 		return err
 	}
@@ -112,8 +103,8 @@ func (r *Resolver) AddNode(item interface{}) error {
 		r.providedBy[t] = n
 	}
 
-	// Now that we have a valid node, we need to add it to the graph.
-	r.graph.AddNode(n)
+	// Now that we have a valid node, we need to save it for later.
+	r.nodes = append(r.nodes, n)
 
 	return nil
 }
@@ -123,21 +114,24 @@ func (r *Resolver) AddNode(item interface{}) error {
 // from these constructors. Any error returned by these constructors will be
 // returned by Resolve if the constructor returns them and is non nil. Note that
 // because this requires a topological sort every time this is run, it is
-// recommended to not use this often.
+// recommended to not use this often. Additionally, all nodes must be added
+// before this method is called.
 func (r *Resolver) Resolve() (inject.Injector, error) {
-	g := simple.NewDirectedGraph()
+	order, err := r.getOrder()
+	if err != nil {
+		return nil, err
+	}
 
-	// Copy the current node graph into a new one, in case we want to do this
-	// later, so the edges don't overlap.
-	graph.Copy(g, r.graph)
+	return createInjector(order)
+}
 
+func (r *Resolver) getOrder() ([]*funcNode, error) {
+	nodeDependencies := map[*funcNode]map[*funcNode]bool{}
 	missingDeps := map[reflect.Type]bool{}
 
 	// Loop over all nodes and add edges for all requirements
-	for _, rawNode := range g.Nodes() {
-		// We need our original node type. Because this is controlled
-		// internally, we don't need to check if this type inference works.
-		n := rawNode.(*funcNode)
+	for _, n := range r.nodes {
+		nodeDependencies[n] = make(map[*funcNode]bool)
 
 		for _, t := range n.requires {
 			depNode, ok := r.providedBy[t]
@@ -146,13 +140,7 @@ func (r *Resolver) Resolve() (inject.Injector, error) {
 				continue
 			}
 
-			// Each requirement is defined as an edge from the dependency to the
-			// dependent nodes. This will cause a topological sort to return the
-			// order in which nodes should be loaded.
-			g.SetEdge(simple.Edge{
-				F: depNode,
-				T: n,
-			})
+			nodeDependencies[n][depNode] = true
 		}
 	}
 
@@ -164,22 +152,54 @@ func (r *Resolver) Resolve() (inject.Injector, error) {
 		return nil, errors.New("Missing dependencies: " + strings.Join(missingDepStrs, ", "))
 	}
 
-	// Now that the full graph with edges is finished, we run a sort and start
-	// working through the dependency nodes.
-	order, err := topo.Sort(g)
-	if err != nil {
-		return nil, err
+	var order []*funcNode
+
+	// Loop through nodeDependencies as long as there are any left
+	for len(nodeDependencies) > 0 {
+		var ready []*funcNode
+
+		for node, deps := range nodeDependencies {
+			if len(deps) > 0 {
+				continue
+			}
+
+			ready = append(ready, node)
+		}
+
+		// If there are no ready nodes, we have a circular dependency
+		if len(ready) == 0 {
+			// TODO: Display the nodes in the cycle
+			return nil, errors.New("Circular dependency found")
+		}
+
+		for _, node := range ready {
+			// Remove the node from what's left to handle.
+			delete(nodeDependencies, node)
+
+			// Add the node to the returned order
+			order = append(order, node)
+
+			// Remove this dependency from other listed nodes.
+			for _, deps := range nodeDependencies {
+				delete(deps, node)
+			}
+		}
 	}
 
+	return order, nil
+}
+
+func createInjector(order []*funcNode) (inject.Injector, error) {
 	// Create a new injector for returning
 	injector := inject.New()
 
 	// For each node, we need to call it, then add the returned values to the
 	// injector.
-	for _, rawNode := range order {
-		n := rawNode.(*funcNode)
+	for _, n := range order {
 		vals, err := injector.Invoke(n.raw)
 		if err != nil {
+			// Note that this shouldn't be possible to hit because we already
+			// ensured there are no missing deps above.
 			return nil, err
 		}
 

--- a/resolve.go
+++ b/resolve.go
@@ -180,8 +180,15 @@ func (r *Resolver) getOrder() ([]*funcNode, error) {
 
 		// If there are no ready nodes, we have a circular dependency
 		if len(ready) == 0 {
-			// TODO: Display the nodes in the cycle
-			return nil, errors.New("Circular dependency found")
+			var depStrings []string
+			for node, deps := range nodeDependencies {
+				var depNames []string
+				for depNode := range deps {
+					depNames = append(depNames, depNode.name)
+				}
+				depStrings = append(depStrings, node.name+" -> "+strings.Join(depNames, " "))
+			}
+			return nil, errors.New("Circular dependency found: " + strings.Join(depStrings, ", "))
 		}
 
 		for _, node := range ready {

--- a/resolve_test.go
+++ b/resolve_test.go
@@ -6,44 +6,37 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"gonum.org/v1/gonum/graph/simple"
 )
 
 // TODO: Ensure the inject.Injector has the values expected
 
 func TestNode(t *testing.T) {
-	g := simple.NewDirectedGraph()
-	nodeID := g.NewNode()
-
 	// Test the happy path with no args
-	n, err := newFuncNode(nodeID, func() {})
-	assert.NoError(t, err, "error while making node")
+	n, err := newFuncNode(func() {})
+	assert.NoError(t, err, "unexpected error while making node")
 
 	assert.Equal(t, len(n.provides), 0, "number of provided types should be 0")
 	assert.Equal(t, len(n.requires), 0, "number of required types should be 0")
 
-	// Ensure the node ID is set properly
-	assert.Equal(t, n.ID(), nodeID.ID(), "Node ID does not match given ID")
-
 	// Ensure we error on a non-function type
-	_, err = newFuncNode(nodeID, 42)
+	_, err = newFuncNode(42)
 	assert.Error(t, err, "no error while making node with invalid type")
 
 	// Ensure we error on nil
-	_, err = newFuncNode(nodeID, nil)
+	_, err = newFuncNode(nil)
 	assert.Error(t, err, "no error while making node with invalid type")
 
 	// Ensure the types match when given one argument
-	n, err = newFuncNode(nodeID, func(int) {})
-	assert.NoError(t, err, "error while making node")
+	n, err = newFuncNode(func(int) {})
+	assert.NoError(t, err, "unexpected error while making node")
 
 	assert.Equal(t, len(n.provides), 0, "number of provided types should be 0")
 	assert.Equal(t, len(n.requires), 1, "number of required types should be 1")
 	assert.Equal(t, n.requires[0].Kind(), reflect.Int, "required type should be Int")
 
 	// Ensure the types match when given one return value
-	n, err = newFuncNode(nodeID, func() int { return 0 })
-	assert.NoError(t, err, "error while making node")
+	n, err = newFuncNode(func() int { return 0 })
+	assert.NoError(t, err, "unexpected error while making node")
 
 	assert.Equal(t, len(n.provides), 1, "number of provided types should be 1")
 	assert.Equal(t, len(n.requires), 0, "number of required types should be 0")
@@ -53,10 +46,11 @@ func TestNode(t *testing.T) {
 func TestAddNode(t *testing.T) {
 	resolver := NewResolver()
 	err := resolver.AddNode(func() {})
-	assert.NoError(t, err, "error while adding node")
+	assert.NoError(t, err, "unexpected error while adding node")
 
-	// Ensure that adding a node to the resolver adds it to the internal graph.
-	assert.Equal(t, len(resolver.graph.Nodes()), 1)
+	// Ensure that adding a node to the resolver adds it to the internal node
+	// list.
+	assert.Equal(t, len(resolver.nodes), 1)
 
 	// Ensure that adding an invalid type will return an error
 	err = resolver.AddNode(1)
@@ -69,7 +63,7 @@ func TestAddNode(t *testing.T) {
 	// Ensure that adding a node which adds provided types will add them to
 	// providedBy.
 	err = resolver.AddNode(func() int { return 42 })
-	assert.NoError(t, err, "error while adding node")
+	assert.NoError(t, err, "unexpected error while adding node")
 
 	// Ensure that adding a node with an overlapping provided type will error.
 	err = resolver.AddNode(func() int { return 42 })
@@ -77,13 +71,10 @@ func TestAddNode(t *testing.T) {
 
 	// Ensure that error doesn't get added to the providedBy mapping
 	err = resolver.AddNode(func() error { return nil })
-	assert.NoError(t, err, "error while adding node")
+	assert.NoError(t, err, "unexpected error while adding node")
 
 	_, ok := resolver.providedBy[errorType]
 	assert.False(t, ok, "error type should not be added to providedBy")
-
-	// Ensure that no edges have been added to the graph.
-	assert.Equal(t, len(resolver.graph.Edges()), 0)
 }
 
 func TestResolve(t *testing.T) {
@@ -143,11 +134,12 @@ func TestResolve(t *testing.T) {
 	_, err = r.Resolve()
 	assert.Error(t, err, "cycle did not cause error")
 
+	// Note that this shouldn't be possible to hit
 	r = NewResolver()
-	n, err := newFuncNode(r.graph.NewNode(), needsInt)
+	n, err := newFuncNode(needsInt)
 	assert.NoError(t, err)
 	n.requires = nil // this will mess up the internal topo sort so we can get to the inject error
-	r.graph.AddNode(n)
+	r.nodes = append(r.nodes, n)
 	_, err = r.Resolve()
 	assert.Error(t, err, "injector did not cause error for requiring missing types")
 }

--- a/resolve_test.go
+++ b/resolve_test.go
@@ -136,6 +136,10 @@ func TestResolve(t *testing.T) {
 	assert.NoError(t, err)
 	_, err = r.Resolve()
 	assert.Error(t, err, "cycle did not cause error")
+	assert.Contains(t, []string{
+		"Circular dependency found: 1 -> 2, 2 -> 1",
+		"Circular dependency found: 2 -> 1, 1 -> 2",
+	}, err.Error(), "unexpected cycle error value")
 
 	// Note that this shouldn't be possible to hit
 	r = NewResolver()


### PR DESCRIPTION
This is roughly based on code from http://dnaeon.github.io/dependency-graph-resolution-algorithm-in-go/ and is being done to remove a dependency which doesn't seem to be compatible with vgo.